### PR TITLE
fixed md module load traj func for bond recalc on line 110

### DIFF
--- a/MolecularNodes/md.py
+++ b/MolecularNodes/md.py
@@ -107,8 +107,34 @@ def load_trajectory(file_top,
     
     
     # determin the bonds for the structure
+    # if hasattr(univ, 'bonds') and include_bonds:
+    #     bonds = univ.bonds.indices
+    # else:
+    #     bonds = []
+
+
+    ##BUGFIX
     if hasattr(univ, 'bonds') and include_bonds:
-        bonds = univ.bonds.indices
+
+        # If there is a selection, we need to recalculate the bond indices
+        if selection != "":
+            index_map = { index:i for i, index in enumerate(univ.atoms.indices) }
+
+            new_bonds = []
+            for bond in univ.bonds.indices:
+                try:
+                    new_index = [index_map[y] for y in bond]
+                    new_bonds.append(new_index)
+                except KeyError:
+                    # fragment - one of the atoms in the bonds was 
+                    # deleted by the selection, so we shouldn't 
+                    # pass this as a bond.  
+                    pass
+                
+            bonds = np.array(new_bonds)
+        else:
+            bonds = univ.bonds.indices
+
     else:
         bonds = []
     

--- a/MolecularNodes/md.py
+++ b/MolecularNodes/md.py
@@ -105,15 +105,7 @@ def load_trajectory(file_top,
             pass
         
     
-    
-    # determin the bonds for the structure
-    # if hasattr(univ, 'bonds') and include_bonds:
-    #     bonds = univ.bonds.indices
-    # else:
-    #     bonds = []
 
-
-    ##BUGFIX
     if hasattr(univ, 'bonds') and include_bonds:
 
         # If there is a selection, we need to recalculate the bond indices


### PR DESCRIPTION
Fixing the bug related to partial selection of a molecule when using Ball and Stick resulting in Blender crash.
The crash in the load_trajectory function in md.py is due to selections using MDAnalysis that references atoms that are not in the selection are left in the bond list.

A solution to resolve this is to reorder the bond indices when residues or fragments are not next to each other and discard bonding where an atom is missing. 