### PR TITLE
bug fix to line 110 md.py

### DIFF
--- a/MolecularNodes/md.py
+++ b/MolecularNodes/md.py
@@ -105,12 +105,32 @@ def load_trajectory(file_top,
             pass
         
     
-    
-    # determin the bonds for the structure
     if hasattr(univ, 'bonds') and include_bonds:
-        bonds = univ.bonds.indices
+        # If there is a selection, we need to recalculate the bond indices
+        if selection != "":
+            index_map = { index:i for i, index in enumerate(univ.atoms.indices) }
+
+            new_bonds = []
+            for bond in univ.bonds.indices:
+                try:
+                    new_index = [index_map[y] for y in bond]
+                    new_bonds.append(new_index)
+                except KeyError:
+                    # fragment - one of the atoms in the bonds was 
+                    # deleted by the selection, so we shouldn't 
+                    # pass this as a bond.  
+                    pass
+                
+            bonds = np.array(new_bonds)
+        else:
+            bonds = univ.bonds.indices
+
     else:
         bonds = []
+
+
+
+    
     
     # create the initial model
     mol_object = create_object(


### PR DESCRIPTION
Fixing the bug related to partial selection of a molecule when using Ball and Stick resulting in Blender crash.
The crash in the load_trajectory function in md.py is due to selections using MDAnalysis that references atoms that are not in the selection are left in the bond list.

A solution to resolve this is to reorder the bond indices when residues or fragments are not next to each other and discard bonding where an atom is missing.